### PR TITLE
Add pkg-config ddprof_ffi.pc

### DIFF
--- a/ddprof-ffi/src/exporter.rs
+++ b/ddprof-ffi/src/exporter.rs
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn profile_exporter_build(
                 converted_files.as_slice(),
                 timeout,
             ) {
-                Ok(response) => Some(Box::new(Request(response))),
+                Ok(request) => Some(Box::new(Request(request))),
                 Err(_) => None,
             }
         }

--- a/ddprof_ffi.pc.in
+++ b/ddprof_ffi.pc.in
@@ -1,0 +1,17 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0. This product includes software
+# developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+# Datadog, Inc.
+
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: ddprof_ffi
+Description: Contains common code used to implement Datadog's Continuous Profilers.
+Version: @version@
+Requires:
+Libs: -L${libdir} -lddprof_ffi -lpthread -ldl -lm
+Libs.private:
+Cflags: -I${includedir}

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <ddprof/ffi.h>
+#include <stdint.h>
+
+/* Creates a profile with one sample type "wall-time" with period of "wall-time"
+ * with unit 60 "nanoseconds". Adds one sample with a string label "language".
+ */
+int main(void) {
+  const struct ddprof_ffi_ValueType wall_time = {
+      .type_ = {"wall-time", sizeof("wall-time") - 1},
+      .unit = {"nanoseconds", sizeof("nanoseconds") - 1},
+  };
+  const struct ddprof_ffi_Slice_value_type sample_types = {&wall_time, 1};
+  const struct ddprof_ffi_Period period = {wall_time, 60};
+  ddprof_ffi_Profile *profile = ddprof_ffi_Profile_new(sample_types, &period);
+
+  struct ddprof_ffi_Line root_line = {
+      .function =
+          (struct ddprof_ffi_Function){.name = {"{main}", sizeof("{main}") - 1},
+                                       .filename = {"/srv/example/index.php"}},
+      .line = 0,
+  };
+
+  struct ddprof_ffi_Location root_location = {
+      // yes, a zero-initialized mapping is valid
+      .mapping = (struct ddprof_ffi_Mapping){},
+      .lines = (struct ddprof_ffi_Slice_line){&root_line, 1},
+  };
+  int64_t value = 10;
+  const struct ddprof_ffi_Label label = {
+      .key = {"language", sizeof("language") - 1},
+      .str = {"php", sizeof("php") - 1},
+  };
+  struct ddprof_ffi_Sample sample = {
+      .locations = {&root_location, 1},
+      .value = {&value, 1},
+      .label = {&label, 1},
+  };
+  ddprof_ffi_Profile_add(profile, sample);
+  ddprof_ffi_Profile_free(profile);
+  return 0;
+}

--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -7,8 +7,10 @@ set -eu
 
 destdir="$1"
 
-mkdir -v -p "$destdir/include/ddprof" "$destdir/lib" "$destdir/cmake"
+mkdir -v -p "$destdir/include/ddprof" "$destdir/lib/pkgconfig" "$destdir/cmake"
 
+version=$(awk -F\" '$1 ~ /^version/ { print $2 }' < ddprof-ffi/Cargo.toml)
+sed "s/@version@/${version}/g" < ddprof_ffi.pc.in > "$destdir/lib/pkgconfig/ddprof_ffi.pc"
 cp -v cmake/DDProfConfig.cmake "$destdir/cmake/"
 cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
 


### PR DESCRIPTION
# What does this PR do?

Add pkg-config file `ddprof_ffi.pc` and test it with `examples/ffi/profiles.c`.

# Motivation

PHP doesn't build with CMake, and that's normal for programming languages created back then. This adds another way to get (at least some) build requirements for such systems through pkg-config.

# Additional Notes

cmake > pkg-config

I learned about `${pcfiledir}` in .pc files; didn't know about that before as I'd never seen anybody use it, but it allows it to be relocatable. This is desirable because we don't know where the user will stick libddprof.

# How to test the change?

Build `examples/ffi/profiles.c` with something like:

```bash
# first, run `bash ffi-build.sh ${DDProf_ROOT}`, then
cd examples/ffi
export PKG_CONFIG_PATH="${DDProf_ROOT}/lib/pkgconfig:$PKG_CONFIG_PATH"
make \
  CFLAGS="$(pkg-config --static --cflags ddprof_ffi)" \
  LDLIBS="$(pkg-config --static --libs ddprof_ffi)" \
  profiles

./profiles
```

Also, the .pc file is only expected to work in CI because it statically links in dependencies like OpenSSL, but locally I don't expect anyone to do it that way, so you'd need to add `-lssl -lcrypto` to LDLIBS on Linux or on Mac something like `-framework CoreFoundation -framework Security`.
