### PR TITLE
Send short commit SHA to libddprof-build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ trigger_internal_build:
   variables:
     LIBDDPROF_COMMIT_BRANCH: $CI_COMMIT_BRANCH
     LIBDDPROF_COMMIT_SHA: $CI_COMMIT_SHA
+    LIBDDPROF_SHORT_COMMIT_SHA: ${CI_COMMIT_SHORT_SHA}
   trigger:
     project: DataDog/libddprof-build
     strategy: depend


### PR DESCRIPTION
# What does this PR do?

Send short commit SHA to libddprof-build
This information is used to define the binary name in Datadog's s3 repository.

# Motivation

Fix the binary naming in s3 insuring that we do not override existing binaries.

# Additional information

if PR https://github.com/DataDog/libddprof/pull/7 is merged, then it will already contain this change.

# How to test the change?

Triggering the downstream build in libddprof-build generates a binary that will contain the short SHA in the name of the binary.

Build link (usable only by Datadog people) : https://gitlab.ddbuild.io/DataDog/libddprof-build/-/jobs/95168459
