### PR TITLE
Simplify string interning

### DIFF
--- a/ddprof-profiles/src/lib.rs
+++ b/ddprof-profiles/src/lib.rs
@@ -278,9 +278,12 @@ impl<T: Sized + Hash + Eq> DedupExt<T> for IndexSet<T> {
         match self.get_index_of(item) {
             Some(index) => index,
             None => {
-                assert!(self.insert(item.into()));
-                self.get_index_of(item)
-                    .expect("value to exist by this point")
+                let (index, inserted) = self.insert_full(item.into());
+                // This wouldn't make any sense; the item couldn't be found so
+                // it was inserted but then it already existed? Screams race-
+                // -condition to me!
+                assert!(inserted);
+                index
             }
         }
     }


### PR DESCRIPTION
# What does this PR do?

Simplify the dedup_ref used in string interning.

# Motivation

This should be slightly more efficient while also being more
understandable.

# Additional Notes

This assertion helped catch a data race condition in a profiler which
used libddprof, which caused the scrutiny of this routine.

# How to test the change?

There shouldn't be any behavior changes; all existing tests should pass.
