### PR TITLE
Adjust per-platform link libraries

### DIFF
--- a/cmake/DDProfConfig.cmake.in
+++ b/cmake/DDProfConfig.cmake.in
@@ -24,7 +24,7 @@ find_package_handle_standard_args(DDProf DEFAULT_MSG
 
 if (DDProf_FOUND)
   set(DDProf_INCLUDE_DIRS ${DDProf_INCLUDE_DIR})
-  set(DDProf_LIBRARIES ${DDProf_FFI_LIBRARY})
+  set(DDProf_LIBRARIES ${DDProf_FFI_LIBRARY} @DDProf_FFI_LIBRARIES@)
   mark_as_advanced(
     DDProf_ROOT
     DDProf_FFI_LIBRARY

--- a/ddprof_ffi.pc.in
+++ b/ddprof_ffi.pc.in
@@ -10,8 +10,8 @@ includedir=${prefix}/include
 
 Name: ddprof_ffi
 Description: Contains common code used to implement Datadog's Continuous Profilers.
-Version: @version@
+Version: @DDProf_FFI_VERSION@
 Requires:
-Libs: -L${libdir} -lddprof_ffi -lpthread -ldl -lm
+Libs: -L${libdir} -lddprof_ffi @DDProf_FFI_LIBRARIES@
 Libs.private:
 Cflags: -I${includedir}

--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -1,7 +1,8 @@
 #/bin/bash
 
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0. This product includes software developed
+# at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
 set -eu
 
@@ -10,15 +11,54 @@ destdir="$1"
 mkdir -v -p "$destdir/include/ddprof" "$destdir/lib/pkgconfig" "$destdir/cmake"
 
 version=$(awk -F\" '$1 ~ /^version/ { print $2 }' < ddprof-ffi/Cargo.toml)
-sed "s/@version@/${version}/g" < ddprof_ffi.pc.in > "$destdir/lib/pkgconfig/ddprof_ffi.pc"
-cp -v cmake/DDProfConfig.cmake "$destdir/cmake/"
+target="$(rustc -vV | awk '/^host:/ { print $2 }')"
+
+case "$target" in
+    "x86_64-alpine-linux-musl")
+        native_static_libs=" -lssp_nonshared -lgcc_s -lc"
+        ;;
+    "x86_64-apple-darwin")
+        native_static_libs=" -framework Security -liconv -lSystem -lresolv -lc -lm -liconv"
+        ;;
+    "x86_64-unknown-linux-gnu")
+        native_static_libs=" -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -ldl -lutil"
+        ;;
+    *)
+        >&2 echo "Unknown platform '${target}'"
+        exit 1
+        ;;
+esac
+
+echo "Recognized platform '${target}'. Adding libs: ${native_static_libs}"
+sed < ddprof_ffi.pc.in "s/@DDProf_FFI_VERSION@/${version}/g" \
+    | sed "s/@DDProf_FFI_LIBRARIES@/${native_static_libs}/g" \
+    > "$destdir/lib/pkgconfig/ddprof_ffi.pc"
+
+sed < cmake/DDProfConfig.cmake.in \
+    > $destdir/cmake/DDProfConfig.cmake \
+    "s/@DDProf_FFI_LIBRARIES@/${native_static_libs}/g"
+
 cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
 
-RUSTFLAGS="${RUSTFLAGS:- -C relocation-model=pic}" cargo build --release
-cp -v target/release/libddprof_ffi.a "$destdir/lib/"
+export RUSTFLAGS="${RUSTFLAGS:- -C relocation-model=pic}"
 
+echo "Building the libddprof_ffi.a library (may take some time)..."
+cargo build --release --target ${target}
+cp -v target/${target}/release/libddprof_ffi.a "$destdir/lib/"
+
+echo "Checking that native-static-libs are as expected for this platform..."
+cd ddprof-ffi
+actual_native_static_libs="$(cargo rustc --release --target ${target} -- --print=native-static-libs 2>&1 | awk -F ':' '/note: native-static-libs:/ { print $3 }')"
+echo "Actual native-static-libs:${actual_native_static_libs}"
+echo "Expected native-static-libs:${native_static_libs}"
+
+[ "${native_static_libs}" = "${actual_native_static_libs}" ]
+cd -
+
+echo "Generating the ddprof/ffi.h header..."
 cbindgen --crate ddprof-ffi --config ddprof-ffi/cbindgen.toml --output "$destdir/include/ddprof/ffi.h"
 
 # CI doesn't have any clang tooling
 # clang-format -i "$destdir/include/ddprof/ffi.h"
 
+echo "Done."


### PR DESCRIPTION
# What does this PR do?

Adjusts the per-platform link libraries included in the pkg-config and
cmake helpers.

# Motivation

While investigating a sigsegv due to strange linking, I realized that
the link libraries that Rust suggests are per platform. 

# Additional Notes

This is brittle. Any change in these flags should be investigated by a
human.

# How to test the change?

Existing build scripts should still work, although there may now be more
runtime dependencies than before. It's unclear to me how many of these
libraries _actually_ need to be linked at runtime, but I don't have a
good programmatic way of figuring out how to pare it down.