### PR TITLE
Improve check of native static libs required for linking

### DIFF
--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -68,7 +68,12 @@ echo "Expected native-static-libs:${expected_native_static_libs}"
 # If actual libs is different from expected libs but still a subset of expected libs
 # (ie. we will overlink compared to what is actually needed), this is not considered as an error.
 # Raise an error only if some libs are in actual libs but not in expected libs.
-unexpected_native_libs=$(comm -13 <(echo $expected_native_static_libs | sed 's/ -/\n-/g' | sort -u) <(echo $actual_native_static_libs | sed 's/ -/\n-/g' | sort -u))
+
+# trim leading and trailing spaces, then split the string on " -" by inserting new lines and sort lines while removing duplicates
+unique_expected_libs=$(echo "$expected_native_static_libs "| awk '{ gsub(/^[ \t]+|[ \t]+$/, "");gsub(/ +-/,"\n-")};1' | sort -u)
+unique_libs=$(echo "$actual_native_static_libs "| awk '{ gsub(/^[ \t]+|[ \t]+$/, "");gsub(/ +-/,"\n-")};1' | sort -u)
+
+unexpected_native_libs=$(comm -13 <(echo "$unique_expected_libs") <(echo "$unique_libs"))
 if [ -n "$unexpected_native_libs" ]; then
     echo "Error - More native static libraries are required for linking than expected:" 1>&2
     echo $unexpected_native_libs 1>&2

--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -64,7 +64,13 @@ actual_native_static_libs="$(cargo rustc --release --target ${target} -- --print
 echo "Actual native-static-libs:${actual_native_static_libs}"
 echo "Expected native-static-libs:${expected_native_static_libs}"
 
-[ "${expected_native_static_libs}" = "${actual_native_static_libs}" ]
+# compute libs in $actual_native_static_libs but not in $expected_native_static_libs
+unexpected_native_libs=$(comm -13 <(echo $expected_native_static_libs | sed 's/ -/\n-/g' | sort -u) <(echo $actual_native_static_libs | sed 's/ -/\n-/g' | sort -u))
+if [ -n "$unexpected_native_libs" ]; then
+    echo "Error - More native static libraries are required for linking than expected:" 1>&2
+    echo $unexpected_native_libs 1>&2
+    exit 1
+fi
 cd -
 
 echo "Generating the ddprof/ffi.h header..."

--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -32,7 +32,7 @@ case "$target" in
         native_static_libs="${expected_native_static_libs}"
         ;;
     "x86_64-unknown-linux-gnu")
-        expected_native_static_libs=" -ldl -lrt -lpthread -lgcc_s -lc -lm -lutil"
+        expected_native_static_libs=" -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -ldl -lutil"
         native_static_libs=" -ldl -lrt -lpthread -lc -lm -lrt -lpthread -lutil -ldl -lutil"
         ;;
     *)

--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -47,7 +47,7 @@ sed < ddprof_ffi.pc.in "s/@DDProf_FFI_VERSION@/${version}/g" \
     > "$destdir/lib/pkgconfig/ddprof_ffi.pc"
 
 sed < cmake/DDProfConfig.cmake.in \
-    > $destdir/cmake/DDProfConfig.cmake \
+    > "$destdir/cmake/DDProfConfig.cmake" \
     "s/@DDProf_FFI_LIBRARIES@/${native_static_libs}/g"
 
 cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
@@ -55,12 +55,12 @@ cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
 export RUSTFLAGS="${RUSTFLAGS:- -C relocation-model=pic}"
 
 echo "Building the libddprof_ffi.a library (may take some time)..."
-cargo build --release --target ${target}
-cp -v target/${target}/release/libddprof_ffi.a "$destdir/lib/"
+cargo build --release --target "${target}"
+cp -v "target/${target}/release/libddprof_ffi.a" "$destdir/lib/"
 
 echo "Checking that native-static-libs are as expected for this platform..."
 cd ddprof-ffi
-actual_native_static_libs="$(cargo rustc --release --target ${target} -- --print=native-static-libs 2>&1 | awk -F ':' '/note: native-static-libs:/ { print $3 }')"
+actual_native_static_libs="$(cargo rustc --release --target "${target}" -- --print=native-static-libs 2>&1 | awk -F ':' '/note: native-static-libs:/ { print $3 }')"
 echo "Actual native-static-libs:${actual_native_static_libs}"
 echo "Expected native-static-libs:${expected_native_static_libs}"
 

--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -32,7 +32,7 @@ case "$target" in
         native_static_libs="${expected_native_static_libs}"
         ;;
     "x86_64-unknown-linux-gnu")
-        expected_native_static_libs=" -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -ldl -lutil"
+        expected_native_static_libs=" -ldl -lrt -lpthread -lgcc_s -lc -lm -lutil"
         native_static_libs=" -ldl -lrt -lpthread -lc -lm -lrt -lpthread -lutil -ldl -lutil"
         ;;
     *)
@@ -64,7 +64,10 @@ actual_native_static_libs="$(cargo rustc --release --target ${target} -- --print
 echo "Actual native-static-libs:${actual_native_static_libs}"
 echo "Expected native-static-libs:${expected_native_static_libs}"
 
-# compute libs in $actual_native_static_libs but not in $expected_native_static_libs
+# Compare unique elements between expected and actual native static libs.
+# If actual libs is different from expected libs but still a subset of expected libs
+# (ie. we will overlink compared to what is actually needed), this is not considered as an error.
+# Raise an error only if some libs are in actual libs but not in expected libs.
 unexpected_native_libs=$(comm -13 <(echo $expected_native_static_libs | sed 's/ -/\n-/g' | sort -u) <(echo $actual_native_static_libs | sed 's/ -/\n-/g' | sort -u))
 if [ -n "$unexpected_native_libs" ]; then
     echo "Error - More native static libraries are required for linking than expected:" 1>&2

--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0. This product includes software developed


### PR DESCRIPTION
# What does this PR do?
* Print an explicit error message when check fails
* Do not fail if there are less actual required libs than required ones

# Motivation

Make ffi-build.sh work on ubuntu 20.04 for which there are less actual static libs than expected ones.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
