### PR TITLE
[PROF-4779] Publish libddprof as a Ruby gem on rubygems.org

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -11,3 +11,5 @@
 .rspec_status
 
 gems.locked
+
+vendor/

--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -1,0 +1,13 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status
+
+gems.locked

--- a/ruby/.rspec
+++ b/ruby/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/ruby/.standard.yml
+++ b/ruby/.standard.yml
@@ -1,0 +1,3 @@
+# For available configuration options, see:
+#   https://github.com/testdouble/standard
+ruby_version: 2.1

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,29 @@
+# libddprof Ruby gem
+
+`libddprof` provides a shared library containing common code used in the implementation of Datadog's
+[Continuous Profilers](https://docs.datadoghq.com/tracing/profiler/).
+
+**NOTE**: If you're building a new profiler or want to contribute to Datadog's existing profilers, you've come to the
+right place!
+Otherwise, this is possibly not the droid you were looking for.
+
+## Development
+
+Run `bundle exec rake` to run the tests and the style autofixer.
+You can also run `bundle exec pry` for an interactive prompt that will allow you to experiment.
+
+## Releasing a new version to rubygems.org
+
+Note: No Ruby needed to run this! It all runs inside docker :)
+
+1. [ ] Locate the new libddprof release on GitHub: <https://github.com/DataDog/libddprof/releases>
+2. [ ] Update the `LIB_GITHUB_RELEASES` section of the <Rakefile> with the new version
+3. [ ] Update the <lib/libddprof/version.rb> file with the `LIB_VERSION` and `VERSION` to use
+4. [ ] Commit change, open PR, get it merged
+5. [ ] Release by running `docker-compose run push_to_rubygems`.
+    (When asked for rubygems credentials, check your local friendly 1Password.)
+6. [ ] Verify that release shows up correctly on: <https://rubygems.org/gems/libddprof>
+
+## Contributing
+
+See <../CONTRIBUTING.md>.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -16,12 +16,14 @@ You can also run `bundle exec pry` for an interactive prompt that will allow you
 
 Note: No Ruby needed to run this! It all runs inside docker :)
 
+Note: Publishing new releases to rubygems.org can only be done by Datadog employees.
+
 1. [ ] Locate the new libddprof release on GitHub: <https://github.com/DataDog/libddprof/releases>
 2. [ ] Update the `LIB_GITHUB_RELEASES` section of the <Rakefile> with the new version
 3. [ ] Update the <lib/libddprof/version.rb> file with the `LIB_VERSION` and `VERSION` to use
 4. [ ] Commit change, open PR, get it merged
 5. [ ] Release by running `docker-compose run push_to_rubygems`.
-    (When asked for rubygems credentials, check your local friendly 1Password.)
+    (When asked for rubygems credentials, check your local friendly Datadog 1Password.)
 6. [ ] Verify that release shows up correctly on: <https://rubygems.org/gems/libddprof>
 
 ## Contributing

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,10 +1,149 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rspec/core/rake_task" unless RUBY_VERSION < "2.5"
+require "rspec/core/rake_task"
+require "standard/rake" unless RUBY_VERSION < "2.5"
+
+require "fileutils"
+require "http"
+require "pry"
+require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-require "standard/rake"
+LIB_GITHUB_RELEASES = {
+  "0.2.0" => [
+    {
+      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
+      sha256: "cba0f24074d44781d7252b912faff50d330957e84a8f40a172a8138e81001f27",
+      ruby_platform: "x86_64-linux"
+    },
+    {
+      file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
+      sha256: "d519a6241d78260522624b8e79e98502510f11d5d9551f5f80fc1134e95fa146",
+      ruby_platform: "x86_64-linux-musl"
+    }
+  ]
+  # Add more versions here
+}
 
-task default: %i[spec standard]
+task default: [
+  :spec,
+  (:'standard:fix' unless RUBY_VERSION < "2.5")
+].compact
+
+desc "Download lib release from github"
+task :fetch do
+  Helpers.each_github_release_variant do |file:, sha256:, target_directory:, target_file:, **_|
+    target_url = "https://github.com/DataDog/libddprof/releases/download/v#{Libddprof::LIB_VERSION}/#{file}"
+
+    if File.exist?(target_file)
+      if Digest::SHA256.hexdigest(File.read(target_file)) == sha256
+        puts "Found #{target_file} matching the expected sha256, skipping download"
+        next
+      else
+        puts "Found #{target_file} BUT IT DID NOT MATCH THE EXPECTED sha256, skipping download"
+      end
+    end
+
+    puts "Going to download #{target_url} into #{target_file}"
+
+    File.open(target_file, "wb") do |file|
+      HTTP.follow.get(target_url).body.each { |chunk| file.write(chunk) }
+    end
+
+    if Digest::SHA256.hexdigest(File.read(target_file)) == sha256
+      puts "Success!"
+    else
+      raise "Downloaded file is corrupt, does not match expected sha256"
+    end
+  end
+end
+
+desc "Extract lib downloaded releases"
+task extract: [:fetch] do
+  Helpers.each_github_release_variant do |target_directory:, target_file:, **_|
+    puts "Extracting #{target_file}"
+    File.open(target_file, "rb") do |file|
+      Gem::Package.new("").extract_tar_gz(file, target_directory)
+    end
+  end
+end
+
+desc "Package lib downloaded releases as gems"
+task package: [:spec, :'standard:fix', :extract] do
+  gemspec = eval(File.read("libddprof.gemspec"), nil, "libddprof.gemspec") # standard:disable Security/Eval
+  FileUtils.mkdir_p("pkg")
+
+  Helpers.package_without_binaries(gemspec)
+  Helpers.package_linux_x86_64(gemspec)
+end
+
+desc "Release all packaged gems"
+task push_to_rubygems: [
+  :package,
+  :'release:guard_clean'
+] do
+  system("gem signout") # make sure there are no existing credentials in use
+
+  system("gem push pkg/libddprof-#{Libddprof::VERSION}.gem")
+  system("gem push pkg/libddprof-#{Libddprof::VERSION}-x86_64-linux.gem")
+
+  system("gem signout") # leave no credentials behind
+end
+
+module Helpers
+  def self.each_github_release_variant(version: Libddprof::LIB_VERSION)
+    LIB_GITHUB_RELEASES.fetch(version).each do |variant|
+      file = variant.fetch(:file)
+      sha256 = variant.fetch(:sha256)
+      ruby_platform = variant.fetch(:ruby_platform)
+
+      # These two are so common that we just centralize them here
+      target_directory = "vendor/libddprof-#{version}/#{ruby_platform}"
+      target_file = "#{target_directory}/#{file}"
+
+      FileUtils.mkdir_p(target_directory)
+
+      yield(file: file, sha256: sha256, ruby_platform: ruby_platform, target_directory: target_directory, target_file: target_file)
+    end
+  end
+
+  def self.package_without_binaries(gemspec)
+    target_gemspec = gemspec.dup
+
+    puts "Building a variant without binaries including:"
+    pp target_gemspec.files
+
+    package = Gem::Package.build(target_gemspec)
+    FileUtils.mv(package, "pkg")
+    puts("-" * 80)
+  end
+
+  def self.package_linux_x86_64(gemspec)
+    # We include both glibc and musl variants in the same binary gem to avoid the issues
+    # documented in https://github.com/rubygems/rubygems/issues/3174
+    target_gemspec = gemspec.dup
+    target_gemspec.files += files_for("x86_64-linux", "x86_64-linux-musl")
+    target_gemspec.platform = "x86_64-linux"
+
+    puts "Building for x86_64-linux including: (this can take a while)"
+    pp target_gemspec.files
+
+    package = Gem::Package.build(target_gemspec)
+    FileUtils.mv(package, "pkg")
+    puts("-" * 80)
+  end
+
+  def self.files_for(*included_platforms, version: Libddprof::LIB_VERSION)
+    files = []
+
+    each_github_release_variant(version: version) do |ruby_platform:, target_directory:, target_file:, **_|
+      next unless included_platforms.include?(ruby_platform)
+
+      files += Dir.glob("#{target_directory}/**/*").select { |path| File.file?(path) } - [target_file]
+    end
+
+    files
+  end
+end

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -38,11 +38,13 @@ task :fetch do
     target_url = "https://github.com/DataDog/libddprof/releases/download/v#{Libddprof::LIB_VERSION}/#{file}"
 
     if File.exist?(target_file)
-      if Digest::SHA256.hexdigest(File.read(target_file)) == sha256
+      target_file_hash = Digest::SHA256.hexdigest(File.read(target_file))
+
+      if target_file_hash == sha256
         puts "Found #{target_file} matching the expected sha256, skipping download"
         next
       else
-        puts "Found #{target_file} BUT IT DID NOT MATCH THE EXPECTED sha256, skipping download"
+        puts "Found #{target_file} with hash (#{target_file_hash}) BUT IT DID NOT MATCH THE EXPECTED sha256 (#{sha256}), downloading it again..."
       end
     end
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task" unless RUBY_VERSION < "2.5"
+
+RSpec::Core::RakeTask.new(:spec)
+
+require "standard/rake"
+
+task default: %i[spec standard]

--- a/ruby/docker-compose.yml
+++ b/ruby/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.2'
+services:
+  push_to_rubygems:
+    image: ruby:3.1
+    platform: linux/x86_64
+    stdin_open: true
+    tty: true
+    command: bash -c 'cd /libddprof/ruby && bundle install && bundle exec rake push_to_rubygems'
+    volumes:
+      - ..:/libddprof
+      - bundle-3.1:/usr/local/bundle
+
+volumes:
+  bundle-3.1:

--- a/ruby/gems.rb
+++ b/ruby/gems.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in libddprof.gemspec
+gemspec
+
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.10"
+gem "standard", "~> 1.3" unless RUBY_VERSION < "2.5"

--- a/ruby/gems.rb
+++ b/ruby/gems.rb
@@ -8,3 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.10"
 gem "standard", "~> 1.3" unless RUBY_VERSION < "2.5"
+gem "http", "~> 5.0"
+gem "pry"
+gem "pry-byebug"

--- a/ruby/lib/libddprof.rb
+++ b/ruby/lib/libddprof.rb
@@ -3,4 +3,28 @@
 require_relative "libddprof/version"
 
 module Libddprof
+  # Is this a no-op libddprof release without binaries?
+  def self.no_binaries?
+    available_binaries.empty?
+  end
+
+  def self.available_binaries
+    Dir.children(vendor_directory)
+  end
+
+  def self.pkgconfig_folder
+    current_platform = Gem::Platform.local.to_s
+
+    return unless available_binaries.include?(current_platform)
+
+    pkgconfig_file = Dir.glob("#{vendor_directory}/#{current_platform}/**/ddprof_ffi.pc").first
+
+    return unless pkgconfig_file
+
+    File.absolute_path(File.dirname(pkgconfig_file))
+  end
+
+  private_class_method def self.vendor_directory
+    ENV["LIBDDPROF_VENDOR_OVERRIDE"] || "#{__dir__}/../vendor/libddprof-#{Libddprof::LIB_VERSION}/"
+  end
 end

--- a/ruby/lib/libddprof.rb
+++ b/ruby/lib/libddprof.rb
@@ -3,11 +3,12 @@
 require_relative "libddprof/version"
 
 module Libddprof
-  # Is this a no-op libddprof release without binaries?
-  def self.no_binaries?
-    available_binaries.empty?
+  # Does this libddprof release include any binaries?
+  def self.binaries?
+    available_binaries.any?
   end
 
+  # This should only be used for debugging/logging
   def self.available_binaries
     File.directory?(vendor_directory) ? Dir.children(vendor_directory) : []
   end

--- a/ruby/lib/libddprof.rb
+++ b/ruby/lib/libddprof.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative "libddprof/version"
+
+module Libddprof
+end

--- a/ruby/lib/libddprof.rb
+++ b/ruby/lib/libddprof.rb
@@ -9,7 +9,7 @@ module Libddprof
   end
 
   def self.available_binaries
-    Dir.children(vendor_directory)
+    File.directory?(vendor_directory) ? Dir.children(vendor_directory) : []
   end
 
   def self.pkgconfig_folder

--- a/ruby/lib/libddprof/version.rb
+++ b/ruby/lib/libddprof/version.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Libddprof
-  VERSION = "0.2.0.beta1"
+  # Current libddprof version
+  LIB_VERSION = "0.2.0"
+
+  # This is the Ruby gem version -- often it will match LIB_VERSION, but sometimes it may not
+  VERSION = "#{LIB_VERSION}.beta1"
 end

--- a/ruby/lib/libddprof/version.rb
+++ b/ruby/lib/libddprof/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Libddprof
+  VERSION = "0.2.0.beta1"
+end

--- a/ruby/lib/libddprof/version.rb
+++ b/ruby/lib/libddprof/version.rb
@@ -4,6 +4,14 @@ module Libddprof
   # Current libddprof version
   LIB_VERSION = "0.2.0"
 
-  # This is the Ruby gem version -- often it will match LIB_VERSION, but sometimes it may not
-  VERSION = "#{LIB_VERSION}.beta2"
+  GEM_MAJOR_VERSION = "1"
+  GEM_MINOR_VERSION = "0"
+  GEM_PRERELEASE_VERSION = ".beta3"
+  private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
+
+  # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].
+  # This allows a version constraint such as ~> 0.2.0.1.0 in the consumer (ddtrace), in essence pinning the libddprof to
+  # a specific version like = 0.2.0, but still allow a) introduction of a gem-level breaking change by bumping gem_major
+  # and b) allow to push automatically picked up bugfixes by bumping gem_minor.
+  VERSION = "#{LIB_VERSION}.#{GEM_MAJOR_VERSION}.#{GEM_MINOR_VERSION}#{GEM_PRERELEASE_VERSION}"
 end

--- a/ruby/lib/libddprof/version.rb
+++ b/ruby/lib/libddprof/version.rb
@@ -5,5 +5,5 @@ module Libddprof
   LIB_VERSION = "0.2.0"
 
   # This is the Ruby gem version -- often it will match LIB_VERSION, but sometimes it may not
-  VERSION = "#{LIB_VERSION}.beta1"
+  VERSION = "#{LIB_VERSION}.beta2"
 end

--- a/ruby/libddprof.gemspec
+++ b/ruby/libddprof.gemspec
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "libddprof/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "libddprof"
+  spec.version = Libddprof::VERSION
+  spec.authors = ["Datadog, Inc."]
+  spec.email = ["dev@datadoghq.com"]
+
+  spec.summary = "Library of common code used by Datadog Continuous Profiler for Ruby"
+  spec.description =
+    "libddprof contains implementation bits used by Datadog's ddtrace gem as part of its Continuous Profiler feature."
+  spec.homepage = "https://docs.datadoghq.com/tracing/profiler/"
+  spec.required_ruby_version = ">= 2.1.0"
+
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/DataDog/libddprof/tree/main/ruby"
+
+  # Require releases on rubygems.org to be coming from multi-factor-auth-authenticated accounts
+  spec.metadata["rubygems_mfa_required"] = "true"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+    end
+  end
+  spec.require_paths = ["lib"]
+end

--- a/ruby/libddprof.gemspec
+++ b/ruby/libddprof.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.description =
     "libddprof contains implementation bits used by Datadog's ddtrace gem as part of its Continuous Profiler feature."
   spec.homepage = "https://docs.datadoghq.com/tracing/profiler/"
+  spec.license = "Apache-2.0"
   spec.required_ruby_version = ">= 2.1.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Libddprof do
     end
 
     context "when no binaries are available in the vendor directory" do
-      describe ".no_binaries?" do
-        it { expect(Libddprof.no_binaries?).to be true }
+      describe ".binaries?" do
+        it { expect(Libddprof.binaries?).to be false }
       end
 
       describe ".available_binaries" do
@@ -45,8 +45,8 @@ RSpec.describe Libddprof do
     context "when vendor directory does not exist" do
       let(:temporary_directory) { "does/not/exist" }
 
-      describe ".no_binaries?" do
-        it { expect(Libddprof.no_binaries?).to be true }
+      describe ".binaries?" do
+        it { expect(Libddprof.binaries?).to be false }
       end
 
       describe ".available_binaries" do
@@ -64,8 +64,8 @@ RSpec.describe Libddprof do
         Dir.mkdir("#{temporary_directory}/mipsel-linux")
       end
 
-      describe ".no_binaries?" do
-        it { expect(Libddprof.no_binaries?).to be false }
+      describe ".binaries?" do
+        it { expect(Libddprof.binaries?).to be true }
       end
 
       describe ".available_binaries" do

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -24,9 +24,27 @@ RSpec.describe Libddprof do
 
     after do
       FileUtils.remove_dir(temporary_directory)
+    rescue Errno::ENOENT => _e
+      # Do nothing, it's ok
     end
 
     context "when no binaries are available in the vendor directory" do
+      describe ".no_binaries?" do
+        it { expect(Libddprof.no_binaries?).to be true }
+      end
+
+      describe ".available_binaries" do
+        it { expect(Libddprof.available_binaries).to be_empty }
+      end
+
+      describe ".pkgconfig_folder" do
+        it { expect(Libddprof.pkgconfig_folder).to be nil }
+      end
+    end
+
+    context "when vendor directory does not exist" do
+      let(:temporary_directory) { "does/not/exist" }
+
       describe ".no_binaries?" do
         it { expect(Libddprof.no_binaries?).to be true }
       end

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Libddprof do
       end
 
       describe ".available_binaries" do
-        it { expect(Libddprof.available_binaries).to eq ["386-freedos", "mipsel-linux"] }
+        it { expect(Libddprof.available_binaries).to contain_exactly("386-freedos", "mipsel-linux") }
       end
 
       context "for the current platform" do

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Libddprof do
+  it "has a version number" do
+    expect(Libddprof::VERSION).not_to be nil
+  end
+end

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -1,7 +1,79 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+require "fileutils"
+
 RSpec.describe Libddprof do
-  it "has a version number" do
-    expect(Libddprof::VERSION).not_to be nil
+  describe "version constants" do
+    it "has a version number" do
+      expect(Libddprof::VERSION).to_not be nil
+    end
+
+    it "has an upstream libddprof version number" do
+      expect(Libddprof::LIB_VERSION).to_not be nil
+    end
+  end
+
+  describe "binary helper methods" do
+    let(:temporary_directory) { Dir.mktmpdir }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("LIBDDPROF_VENDOR_OVERRIDE").and_return(temporary_directory)
+    end
+
+    after do
+      FileUtils.remove_dir(temporary_directory)
+    end
+
+    context "when no binaries are available in the vendor directory" do
+      describe ".no_binaries?" do
+        it { expect(Libddprof.no_binaries?).to be true }
+      end
+
+      describe ".available_binaries" do
+        it { expect(Libddprof.available_binaries).to be_empty }
+      end
+
+      describe ".pkgconfig_folder" do
+        it { expect(Libddprof.pkgconfig_folder).to be nil }
+      end
+    end
+
+    context "when binaries are available in the vendor directory" do
+      before do
+        Dir.mkdir("#{temporary_directory}/386-freedos")
+        Dir.mkdir("#{temporary_directory}/mipsel-linux")
+      end
+
+      describe ".no_binaries?" do
+        it { expect(Libddprof.no_binaries?).to be false }
+      end
+
+      describe ".available_binaries" do
+        it { expect(Libddprof.available_binaries).to eq ["386-freedos", "mipsel-linux"] }
+      end
+
+      context "for the current platform" do
+        let(:pkgconfig_folder) { "#{temporary_directory}/#{Gem::Platform.local}/some/folder/containing/the/pkgconfig/file" }
+
+        before do
+          FileUtils.mkdir_p(pkgconfig_folder)
+          File.open("#{pkgconfig_folder}/ddprof_ffi.pc", "w") {}
+        end
+
+        describe ".pkgconfig_folder" do
+          it "returns the folder containing the pkgconfig file" do
+            expect(Libddprof.pkgconfig_folder).to eq pkgconfig_folder
+          end
+        end
+      end
+
+      context "but not for the current platform" do
+        describe ".pkgconfig_folder" do
+          it { expect(Libddprof.pkgconfig_folder).to be nil }
+        end
+      end
+    end
   end
 end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "libddprof"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pry"
+
 require "libddprof"
 
 RSpec.configure do |config|


### PR DESCRIPTION
# What does this PR do?

This PR adds the scaffolding for taking a `libddprof` binary release from GitHub, and releasing it as a Ruby gem on [rubygems.org](https://rubygems.org/gems/libddprof).

This allows us to use `libddprof` on [the Ruby profiler shipped in dd-trace-rb](https://github.com/DataDog/dd-trace-rb) in a quite simple way: the released library has almost no code, and effectively just distributes the release files in a way that can be easily consumed by a Ruby library.

The release is mostly-automated (detailed instructions are on README.md)

1. We need to copy-paste the release sha256 for `libbprof`, as well as bump the version
2. And then run `docker-compose run push_to_rubygems`

I will be the one responsible for pushing new releases (on behalf of the profiling team), but still anyone can do a release if needed.

In the future we may want to look at triggering this from CI so that new `libddprof` releases are automatically pushed on rubygems.org.

# Motivation

Having `libddprof` on rubygems.org and managed directly by the Profiling team (e.g. me) decouples releasing and distribution of the dd-trace-rb library from `libddprof`.

# Additional Notes

I've already pushed `libddprof` 0.2.0 on rubygems.org using this PR: https://rubygems.org/gems/libddprof .

The current setup pushes two "variants" of the gem -- one with no binaries, which is used as a "no-op" dependency for platforms that libddprof does not support, and a "fat" one for x86-64 Linux, that includes both the glibc, as well as musl library binaries inside.

# How to test the change?

Testing for this will be done on the consumer side: in the Ruby profiler, which will run libddprof on different platforms and Ruby versions.