### PR TITLE
Bump version to 0.3.0-rc.1

### DIFF
--- a/ddprof-exporter/Cargo.toml
+++ b/ddprof-exporter/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-exporter"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/ddprof-exporter/Cargo.toml
+++ b/ddprof-exporter/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-exporter"
-version = "0.3.0"
+version = "0.3.0-rc.1"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/ddprof-ffi/Cargo.toml
+++ b/ddprof-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-ffi"
-version = "0.3.0"
+version = "0.3.0-rc.1"
 edition = "2018"
 license = "Apache-2.0"
 
@@ -12,7 +12,7 @@ crate-type = ["lib", "staticlib"]
 
 [dependencies]
 chrono = "0.4"
-ddprof-exporter = { path = "../ddprof-exporter", version = "0.3.0" }
-ddprof-profiles = { path = "../ddprof-profiles", version = "0.3.0" }
+ddprof-exporter = { path = "../ddprof-exporter", version = "0.3.0-rc.1" }
+ddprof-profiles = { path = "../ddprof-profiles", version = "0.3.0-rc.1" }
 libc = "0.2"
 reqwest = { version = "0.11", features = ["blocking", "multipart", "rustls-tls"], default-features = false }

--- a/ddprof-ffi/Cargo.toml
+++ b/ddprof-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-ffi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 
@@ -12,7 +12,7 @@ crate-type = ["lib", "staticlib"]
 
 [dependencies]
 chrono = "0.4"
-ddprof-exporter = { path = "../ddprof-exporter", version = "0.2.0" }
-ddprof-profiles = { path = "../ddprof-profiles", version = "0.2.0" }
+ddprof-exporter = { path = "../ddprof-exporter", version = "0.3.0" }
+ddprof-profiles = { path = "../ddprof-profiles", version = "0.3.0" }
 libc = "0.2"
 reqwest = { version = "0.11", features = ["blocking", "multipart", "rustls-tls"], default-features = false }

--- a/ddprof-profiles/Cargo.toml
+++ b/ddprof-profiles/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-profiles"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 build = "build.rs"
 license = "Apache-2.0"

--- a/ddprof-profiles/Cargo.toml
+++ b/ddprof-profiles/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-profiles"
-version = "0.3.0"
+version = "0.3.0-rc.1"
 edition = "2018"
 build = "build.rs"
 license = "Apache-2.0"

--- a/ddprof/Cargo.toml
+++ b/ddprof/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/ddprof/Cargo.toml
+++ b/ddprof/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof"
-version = "0.3.0"
+version = "0.3.0-rc.1"
 edition = "2018"
 license = "Apache-2.0"
 


### PR DESCRIPTION
# What does this PR do?

This bumps the version to 0.3.0-rc.1 in preparation for the next release.

# Motivation

I want to use the container ID feature in the PHP profiler!

# Additional Notes

~I wonder if there's a cargo-blessed way to do `0.3.0-rc.1` instead of lying about being `0.3.0` during all the pre-releases.~ We're just going to try it.

# How to test the change?

There shouldn't be any breaking changes, so test as normal, but you should see container id's after upgrading!
