### PR TITLE
Bump version to v0.3.0

### DIFF
--- a/ddprof-exporter/Cargo.toml
+++ b/ddprof-exporter/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-exporter"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/ddprof-ffi/Cargo.toml
+++ b/ddprof-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-ffi"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 
@@ -12,7 +12,7 @@ crate-type = ["lib", "staticlib"]
 
 [dependencies]
 chrono = "0.4"
-ddprof-exporter = { path = "../ddprof-exporter", version = "0.3.0-rc.1" }
-ddprof-profiles = { path = "../ddprof-profiles", version = "0.3.0-rc.1" }
+ddprof-exporter = { path = "../ddprof-exporter", version = "0.3.0" }
+ddprof-profiles = { path = "../ddprof-profiles", version = "0.3.0" }
 libc = "0.2"
 reqwest = { version = "0.11", features = ["blocking", "multipart", "rustls-tls"], default-features = false }

--- a/ddprof-profiles/Cargo.toml
+++ b/ddprof-profiles/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-profiles"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 edition = "2018"
 build = "build.rs"
 license = "Apache-2.0"

--- a/ddprof/Cargo.toml
+++ b/ddprof/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 


### PR DESCRIPTION
# What does this PR do?

Bumps the version from `0.3.0-rc.1` to `0.3.0`.

# Motivation

I want to run a GA version of libddprof in the next PHP profiler version (0.4.0).

# Additional Notes

PHP profiler has been updated to the `0.3.0-rc.1` release and deployed to the reliability environment. No issues detected.

# How to test the change?

No changes since `-rc.1` was made, so nothing special.
