### PR TITLE
Release libddprof 0.3.0 to rubygems (as 0.3.0.1.0)

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -14,26 +14,26 @@ RSpec::Core::RakeTask.new(:spec)
 LIB_GITHUB_RELEASES = {
   "0.2.0" => [
     {
-      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
-      sha256: "cba0f24074d44781d7252b912faff50d330957e84a8f40a172a8138e81001f27",
-      ruby_platform: "x86_64-linux"
-    },
-    {
       file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
       sha256: "d519a6241d78260522624b8e79e98502510f11d5d9551f5f80fc1134e95fa146",
       ruby_platform: "x86_64-linux-musl"
+    },
+    {
+      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
+      sha256: "cba0f24074d44781d7252b912faff50d330957e84a8f40a172a8138e81001f27",
+      ruby_platform: "x86_64-linux"
     }
   ],
   "0.3.0" => [
     {
-      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
-      sha256: "d9c64567e7ef5f957581dd81892b144b81e1f52fdf5671430c7af0b039b48929",
-      ruby_platform: "x86_64-linux"
-    },
-    {
       file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
       sha256: "854609c1acc86f6653f539b3fe8780ad1e60d8738f85efdb3b1aa0054e75a217",
       ruby_platform: "x86_64-linux-musl"
+    },
+    {
+      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
+      sha256: "d9c64567e7ef5f957581dd81892b144b81e1f52fdf5671430c7af0b039b48929",
+      ruby_platform: "x86_64-linux"
     }
   ]
   # Add more versions here

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -23,6 +23,18 @@ LIB_GITHUB_RELEASES = {
       sha256: "d519a6241d78260522624b8e79e98502510f11d5d9551f5f80fc1134e95fa146",
       ruby_platform: "x86_64-linux-musl"
     }
+  ],
+  "0.3.0" => [
+    {
+      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
+      sha256: "d9c64567e7ef5f957581dd81892b144b81e1f52fdf5671430c7af0b039b48929",
+      ruby_platform: "x86_64-linux"
+    },
+    {
+      file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
+      sha256: "854609c1acc86f6653f539b3fe8780ad1e60d8738f85efdb3b1aa0054e75a217",
+      ruby_platform: "x86_64-linux-musl"
+    }
   ]
   # Add more versions here
 }

--- a/ruby/lib/libddprof/version.rb
+++ b/ruby/lib/libddprof/version.rb
@@ -2,11 +2,11 @@
 
 module Libddprof
   # Current libddprof version
-  LIB_VERSION = "0.2.0"
+  LIB_VERSION = "0.3.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"
-  GEM_PRERELEASE_VERSION = ".beta3"
+  GEM_PRERELEASE_VERSION = "" # remember to include dot prefix, if needed!
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].


### PR DESCRIPTION
I'm following the release checklist in the README.md:

1. [x] Locate the new libddprof release on GitHub: <https://github.com/DataDog/libddprof/releases>
2. [x] Update the `LIB_GITHUB_RELEASES` section of the <Rakefile> with the new version
3. [x] Update the <lib/libddprof/version.rb> file with the `LIB_VERSION` and `VERSION` to use
4. [ ] Commit change, open PR, get it merged
5. [ ] Release by running `docker-compose run push_to_rubygems`.
    (When asked for rubygems credentials, check your local friendly Datadog 1Password.)
6. [ ] Verify that release shows up correctly on: <https://rubygems.org/gems/libddprof>

---

# What does this PR do?

Release the latest libddprof 0.3.0 to rubygems.org

# Additional Notes

This should only be merged after #19 goes in.

# How to test the change?

CI is green + more tests will be done in the dd-trace-rb side.