### PR TITLE
Add support for packaging shared library for Ruby on x86-64 Linux and macOS

### DIFF
--- a/ddprof_ffi.pc.in
+++ b/ddprof_ffi.pc.in
@@ -9,7 +9,7 @@ libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: ddprof_ffi
-Description: Contains common code used to implement Datadog's Continuous Profilers.
+Description: Contains common code used to implement Datadog's Continuous Profilers. (Dynamic linking variant)
 Version: @DDProf_FFI_VERSION@
 Requires:
 Libs: -L${libdir} -lddprof_ffi

--- a/ddprof_ffi_with_rpath.pc.in
+++ b/ddprof_ffi_with_rpath.pc.in
@@ -9,9 +9,9 @@ libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: ddprof_ffi
-Description: Contains common code used to implement Datadog's Continuous Profilers. (Static linking variant)
+Description: Contains common code used to implement Datadog's Continuous Profilers. (Dynamic linking variant, sets rpath)
 Version: @DDProf_FFI_VERSION@
 Requires:
-Libs: -L${libdir} ${libdir}/libddprof_ffi.a @DDProf_FFI_LIBRARIES@
+Libs: -L${libdir} -lddprof_ffi -Wl,-rpath,${libdir}
 Libs.private:
 Cflags: -I${includedir}

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -141,6 +141,7 @@ module Helpers
     *included_platforms,
     version: Libddprof::LIB_VERSION,
     excluded_files: [
+      "ddprof_ffi.pc", # we use the ddprof_ffi_with_rpath.pc variant
       "libddprof_ffi.a", "ddprof_ffi-static.pc" # We don't use the static library
     ]
   )

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -82,15 +82,15 @@ task package: [
   FileUtils.mkdir_p("pkg")
 
   # Fallback package without binaries
-  Helpers.package_for(gemspec, ruby_platform: nil, included_platforms: [])
+  Helpers.package_for(gemspec, ruby_platform: nil, files: [])
 
   # We include both glibc and musl variants in the same binary gem to avoid the issues
   # documented in https://github.com/rubygems/rubygems/issues/3174
-  Helpers.package_for(gemspec, ruby_platform: "x86_64-linux", included_platforms: ["x86_64-linux", "x86_64-linux-musl"])
+  Helpers.package_for(gemspec, ruby_platform: "x86_64-linux", files: Helpers.files_for("x86_64-linux", "x86_64-linux-musl"))
 
   # Experimental macOS package, not published to rubygems.org at the moment
   if ENV["LIBDDPROF_PACKAGE_MACOS"] == "true"
-    Helpers.package_for(gemspec, ruby_platform: "x86_64-darwin", included_platforms: ["x86_64-darwin"])
+    Helpers.package_for(gemspec, ruby_platform: "x86_64-darwin", files: Helpers.files_for("x86_64-darwin"), excluded_files: [])
   end
 end
 
@@ -124,9 +124,9 @@ module Helpers
     end
   end
 
-  def self.package_for(gemspec, ruby_platform:, included_platforms:)
+  def self.package_for(gemspec, ruby_platform:, files:)
     target_gemspec = gemspec.dup
-    target_gemspec.files += files_for(included_platforms) if included_platforms.any?
+    target_gemspec.files += files
     target_gemspec.platform = ruby_platform if ruby_platform
 
     puts "Building with ruby_platform=#{ruby_platform.inspect} including: (this can take a while)"
@@ -137,10 +137,17 @@ module Helpers
     puts("-" * 80)
   end
 
-  def self.files_for(included_platforms, version: Libddprof::LIB_VERSION)
+  def self.files_for(
+    *included_platforms,
+    version: Libddprof::LIB_VERSION,
+    excluded_files: [
+      "libddprof_ffi.a", "ddprof_ffi-static.pc", # We don't use the static library
+    ]
+  )
     files = []
 
     excluded_files_from_packaging = [
+      *excluded_files,
       "DDProfConfig.cmake", # We don't compile using cmake
     ]
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -81,8 +81,17 @@ task package: [
   gemspec = eval(File.read("libddprof.gemspec"), nil, "libddprof.gemspec") # standard:disable Security/Eval
   FileUtils.mkdir_p("pkg")
 
-  Helpers.package_without_binaries(gemspec)
-  Helpers.package_linux_x86_64(gemspec)
+  # Fallback package without binaries
+  Helpers.package_for(gemspec, ruby_platform: nil, included_platforms: [])
+
+  # We include both glibc and musl variants in the same binary gem to avoid the issues
+  # documented in https://github.com/rubygems/rubygems/issues/3174
+  Helpers.package_for(gemspec, ruby_platform: "x86_64-linux", included_platforms: ["x86_64-linux", "x86_64-linux-musl"])
+
+  # Experimental macOS package, not published to rubygems.org at the moment
+  if ENV["LIBDDPROF_PACKAGE_MACOS"] == "true"
+    Helpers.package_for(gemspec, ruby_platform: "x86_64-darwin", included_platforms: ["x86_64-darwin"])
+  end
 end
 
 desc "Release all packaged gems"
@@ -115,10 +124,12 @@ module Helpers
     end
   end
 
-  def self.package_without_binaries(gemspec)
+  def self.package_for(gemspec, ruby_platform:, included_platforms:)
     target_gemspec = gemspec.dup
+    target_gemspec.files += files_for(included_platforms) if included_platforms.any?
+    target_gemspec.platform = ruby_platform if ruby_platform
 
-    puts "Building a variant without binaries including:"
+    puts "Building with ruby_platform=#{ruby_platform.inspect} including: (this can take a while)"
     pp target_gemspec.files
 
     package = Gem::Package.build(target_gemspec)
@@ -126,28 +137,18 @@ module Helpers
     puts("-" * 80)
   end
 
-  def self.package_linux_x86_64(gemspec)
-    # We include both glibc and musl variants in the same binary gem to avoid the issues
-    # documented in https://github.com/rubygems/rubygems/issues/3174
-    target_gemspec = gemspec.dup
-    target_gemspec.files += files_for("x86_64-linux", "x86_64-linux-musl")
-    target_gemspec.platform = "x86_64-linux"
-
-    puts "Building for x86_64-linux including: (this can take a while)"
-    pp target_gemspec.files
-
-    package = Gem::Package.build(target_gemspec)
-    FileUtils.mv(package, "pkg")
-    puts("-" * 80)
-  end
-
-  def self.files_for(*included_platforms, version: Libddprof::LIB_VERSION)
+  def self.files_for(included_platforms, version: Libddprof::LIB_VERSION)
     files = []
 
     each_github_release_variant(version: version) do |ruby_platform:, target_directory:, target_file:, **_|
       next unless included_platforms.include?(ruby_platform)
 
-      files += Dir.glob("#{target_directory}/**/*").select { |path| File.file?(path) } - [target_file]
+      downloaded_release_tarball = target_file
+
+      files +=
+        Dir.glob("#{target_directory}/**/*")
+          .select { |path| File.file?(path) }
+          .reject { |path| path == downloaded_release_tarball }
     end
 
     files

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -90,7 +90,7 @@ task package: [
 
   # Experimental macOS package, not published to rubygems.org at the moment
   if ENV["LIBDDPROF_PACKAGE_MACOS"] == "true"
-    Helpers.package_for(gemspec, ruby_platform: "x86_64-darwin", files: Helpers.files_for("x86_64-darwin"), excluded_files: [])
+    Helpers.package_for(gemspec, ruby_platform: "x86_64-darwin-19", files: Helpers.files_for("x86_64-darwin-19"))
   end
 end
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -140,6 +140,10 @@ module Helpers
   def self.files_for(included_platforms, version: Libddprof::LIB_VERSION)
     files = []
 
+    excluded_files_from_packaging = [
+      "DDProfConfig.cmake", # We don't compile using cmake
+    ]
+
     each_github_release_variant(version: version) do |ruby_platform:, target_directory:, target_file:, **_|
       next unless included_platforms.include?(ruby_platform)
 
@@ -149,6 +153,7 @@ module Helpers
         Dir.glob("#{target_directory}/**/*")
           .select { |path| File.file?(path) }
           .reject { |path| path == downloaded_release_tarball }
+          .reject { |path| excluded_files_from_packaging.include?(File.basename(path)) }
     end
 
     files

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -2,7 +2,7 @@
 
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-require "standard/rake" unless RUBY_VERSION < "2.5"
+require "standard/rake" unless RUBY_VERSION < "2.6"
 
 require "fileutils"
 require "http" unless RUBY_VERSION < "2.5"
@@ -41,7 +41,7 @@ LIB_GITHUB_RELEASES = {
 
 task default: [
   :spec,
-  (:'standard:fix' unless RUBY_VERSION < "2.5")
+  (:'standard:fix' unless RUBY_VERSION < "2.6")
 ].compact
 
 desc "Download lib release from github"
@@ -85,7 +85,11 @@ task extract: [:fetch] do
 end
 
 desc "Package lib downloaded releases as gems"
-task package: [:spec, :'standard:fix', :extract] do
+task package: [
+  :spec,
+  (:'standard:fix' unless RUBY_VERSION < "2.6"),
+  :extract
+] do
   gemspec = eval(File.read("libddprof.gemspec"), nil, "libddprof.gemspec") # standard:disable Security/Eval
   FileUtils.mkdir_p("pkg")
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -12,18 +12,7 @@ require "rubygems/package"
 RSpec::Core::RakeTask.new(:spec)
 
 LIB_GITHUB_RELEASES = {
-  "0.2.0" => [
-    {
-      file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
-      sha256: "d519a6241d78260522624b8e79e98502510f11d5d9551f5f80fc1134e95fa146",
-      ruby_platform: "x86_64-linux-musl"
-    },
-    {
-      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
-      sha256: "cba0f24074d44781d7252b912faff50d330957e84a8f40a172a8138e81001f27",
-      ruby_platform: "x86_64-linux"
-    }
-  ],
+  # This should match the version in the version.rb file
   "0.3.0" => [
     {
       file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
@@ -36,7 +25,6 @@ LIB_GITHUB_RELEASES = {
       ruby_platform: "x86_64-linux"
     }
   ]
-  # Add more versions here
 }
 
 task default: [

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -141,14 +141,14 @@ module Helpers
     *included_platforms,
     version: Libddprof::LIB_VERSION,
     excluded_files: [
-      "libddprof_ffi.a", "ddprof_ffi-static.pc", # We don't use the static library
+      "libddprof_ffi.a", "ddprof_ffi-static.pc" # We don't use the static library
     ]
   )
     files = []
 
     excluded_files_from_packaging = [
       *excluded_files,
-      "DDProfConfig.cmake", # We don't compile using cmake
+      "DDProfConfig.cmake" # We don't compile using cmake
     ]
 
     each_github_release_variant(version: version) do |ruby_platform:, target_directory:, target_file:, **_|

--- a/ruby/gems.rb
+++ b/ruby/gems.rb
@@ -7,7 +7,7 @@ gemspec
 
 gem "rake", ">= 12.0", "< 14"
 gem "rspec", "~> 3.10"
-gem "standard", "~> 1.3" unless RUBY_VERSION < "2.5"
+gem "standard", "~> 1.7", ">= 1.7.2" unless RUBY_VERSION < "2.6"
 gem "http", "~> 5.0" unless RUBY_VERSION < "2.5"
 gem "pry"
 gem "pry-byebug" unless RUBY_VERSION > "3.1"

--- a/ruby/lib/libddprof/version.rb
+++ b/ruby/lib/libddprof/version.rb
@@ -4,9 +4,9 @@ module Libddprof
   # Current libddprof version
   LIB_VERSION = "0.3.0"
 
-  GEM_MAJOR_VERSION = "1"
+  GEM_MAJOR_VERSION = "2"
   GEM_MINOR_VERSION = "0"
-  GEM_PRERELEASE_VERSION = "" # remember to include dot prefix, if needed!
+  GEM_PRERELEASE_VERSION = ".beta1" # remember to include dot prefix, if needed!
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].

--- a/ruby/libddprof.gemspec
+++ b/ruby/libddprof.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
         (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
       end
       .reject do |f|
-        ['.rspec', '.standard.yml', 'Rakefile', 'docker-compose.yml', 'gems.rb', 'README.md'].include?(f)
+        [".rspec", ".standard.yml", "Rakefile", "docker-compose.yml", "gems.rb", "README.md"].include?(f)
       end
   end
   spec.require_paths = ["lib"]

--- a/ruby/libddprof.gemspec
+++ b/ruby/libddprof.gemspec
@@ -28,9 +28,14 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
-    end
+    `git ls-files -z`
+      .split("\x0")
+      .reject do |f|
+        (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+      end
+      .reject do |f|
+        ['.rspec', '.standard.yml', 'Rakefile', 'docker-compose.yml', 'gems.rb', 'README.md'].include?(f)
+      end
   end
   spec.require_paths = ["lib"]
 end

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Libddprof do
     end
 
     after do
-      begin # standard:disable Style/RedundantBegin
+      begin
         FileUtils.remove_dir(temporary_directory)
       rescue Errno::ENOENT => _e
         # Do nothing, it's ok


### PR DESCRIPTION
# What does this PR do?

* Changes the Ruby packaging script to package the shared library version of libddprof.
* Adds a new `ddprof_ffi_with_rpath.pc` file that allows a user of libddprof to link and run with libddprof being installed on any folder
* Enables packaging for macOS using an extra environment variable. We don't yet have binaries, so this is only for development use.
* Includes a few more cleanups to the Ruby packaging code (see commit messages for details)

# Motivation

Package up shared library version for Ruby.

# How to test the change?

The addition of `ddprof_ffi_with_rpath.pc` change can be tested by compiling/linking to libddprof using pkg-config and keeping libddprof in the build folder, separate from the compiled app.

The Ruby changes can't be tested right now, because we don't yet have published binaries for v0.4.0. I've tested them locally, and I'll open a follow-up PR once we're ready to package the final v0.4.0 for Ruby.
