### PR TITLE
Fix `ffi-build.sh: line 78: fix_macos_rpath: unbound variable` issue on Linux

### DIFF
--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -14,6 +14,7 @@ version=$(awk -F\" '$1 ~ /^version/ { print $2 }' < ddprof-ffi/Cargo.toml)
 target="$(rustc -vV | awk '/^host:/ { print $2 }')"
 shared_library_suffix=".so"
 remove_rpath=0
+fix_macos_rpath=0
 
 # Rust provides this note about the link libraries:
 # note: Link against the following native artifacts when linking against this


### PR DESCRIPTION
# What does this PR do?

Fix `ffi-build.sh: line 78: fix_macos_rpath: unbound variable` issue that appeared on Linux after the changes in #26.

# Motivation

Having things actually working :)

# How to test the change?

Running `ffi-build.sh` on Linux and confirming it is successful.