### PR TITLE
Create `strip`d version of shared library during build

### DIFF
--- a/ffi-build.sh
+++ b/ffi-build.sh
@@ -86,6 +86,10 @@ if command -v objcopy > /dev/null; then
     objcopy --remove-section .llvmbc "$destdir/lib/libddprof_ffi.a"
 fi
 
+echo "Running strip on libddprof_ffi and keeping an unstrip'd copy as libddprof_ffi_debug..."
+cp "$destdir/lib/libddprof_ffi${shared_library_suffix}" "$destdir/lib/libddprof_ffi_debug${shared_library_suffix}"
+strip -S "$destdir/lib/libddprof_ffi${shared_library_suffix}"
+
 echo "Checking that native-static-libs are as expected for this platform..."
 cd ddprof-ffi
 actual_native_static_libs="$(cargo rustc --release --target "${target}" -- --print=native-static-libs 2>&1 | awk -F ':' '/note: native-static-libs:/ { print $3 }')"


### PR DESCRIPTION
# What does this PR do?

Changes `ffi-build.sh` to create two versions of the shared library: one that has been `strip`d, and another which hasn't.

# Motivation

By having the build generate both a `strip`d and an unstrip'd version of the shared library, we make it easier to package a `strip`d libddprof without needing access to all architectures and OS's used to build the binaries.

In particular for Ruby, it allows the Ruby packaging process to be just a straightforward unpacking + uploading to rubygems.org, without any kind of changes to the libddprof files.

It also makes it easier to validate the resulting libddprof distribution: it should match the exact files present in the release page on GitHub.

Finally, there was a bit of discussion if we should ship both `strip`d and unstrip'd, or only ship the `strip`d version but I like having both since it makes it easy to package a version with full debug info if we need to investigate an issue. (Totally open to switching to the other option)

# How to test the change?

Exercise the `strip`d version of libddprof shared library by linking to, and using it.