### PR TITLE
Increase reported profile timestamp precision

### DIFF
--- a/ddprof-exporter/src/lib.rs
+++ b/ddprof-exporter/src/lib.rs
@@ -118,8 +118,8 @@ impl ProfileExporterV3 {
 
         let mut form = reqwest::multipart::Form::new()
             .text("version", "3")
-            .text("start", start.format("%Y-%m-%dT%H:%M:%SZ").to_string())
-            .text("end", end.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+            .text("start", start.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string())
+            .text("end", end.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string())
             .text("family", String::from(&self.family));
 
         for tag in self.tags.iter() {


### PR DESCRIPTION
# What does this PR do?

Increase the reported `start` / `end` timestamp precision from seconds to nanoseconds.

# Motivation

Currently, Java uses microsecond precision for uploaded profile start/end, whereas Ruby, Python, Go and libddprof use second precision.

While discussing with @flodav he made a good point that just truncating the start and end would mean that we could induce quite a bit of error.

I decided to bump it to nanos, since we have it anyway. Open to change, if it's overkill :)

# How to test the change?

Confirm that the increased precision is visible in a libddprof request. (I tested it locally with the Ruby profiler).
