### PR TITLE
[PROF-4780] Breaking change: Change FFI File struct to contain a Buffer instead of a ByteSlice

### DIFF
--- a/examples/ffi/CMakeLists.txt
+++ b/examples/ffi/CMakeLists.txt
@@ -2,9 +2,9 @@ project(ffi_examples)
 cmake_minimum_required(VERSION 3.19)
 
 find_package(DDProf)
-set(CMAKE_CXX_STANDARD 11)
 
 add_executable(exporter exporter.cpp)
+target_compile_features(exporter PRIVATE cxx_std_11)
 target_link_libraries(exporter DDProf::FFI)
 add_executable(profiles profiles.c)
 target_link_libraries(profiles DDProf::FFI)

--- a/examples/ffi/CMakeLists.txt
+++ b/examples/ffi/CMakeLists.txt
@@ -2,6 +2,7 @@ project(ffi_examples)
 cmake_minimum_required(VERSION 3.19)
 
 find_package(DDProf)
+set(CMAKE_CXX_STANDARD 11)
 
 add_executable(exporter exporter.cpp)
 target_link_libraries(exporter DDProf::FFI)

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -120,15 +120,9 @@ int main(int argc, char* argv[])
 
     Holder<ddprof_ffi_ProfileExporterV3> exporter{exporter_new_result.ok};
 
-    ddprof_ffi_Buffer profile_buffer = {
-        .ptr = encoded_profile->buffer.ptr,
-        .len = encoded_profile->buffer.len,
-        .capacity = encoded_profile->buffer.capacity,
-    };
-
     ddprof_ffi_File files_[] = {{
         .name = to_byteslice("auto.pprof"),
-        .file = &profile_buffer,
+        .file = (ddprof_ffi_ByteSlice) {.ptr = encoded_profile->buffer.ptr, .len = encoded_profile->buffer.len},
     }};
 
     ddprof_ffi_Slice_file files = {

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
 
     ddprof_ffi_File files_[] = {{
         .name = to_byteslice("auto.pprof"),
-        .file = (ddprof_ffi_ByteSlice) {.ptr = encoded_profile->buffer.ptr, .len = encoded_profile->buffer.len},
+        .file = {.ptr = encoded_profile->buffer.ptr, .len = encoded_profile->buffer.len},
     }};
 
     ddprof_ffi_Slice_file files = {


### PR DESCRIPTION
# What does this PR do? + Motivation

In #30 we added the `ddprof_ffi_Buffer_from_byte_slice` function to allow FFI users to provide their own data to be reported using the `ProfileExporterV3` (via `ddprof_ffi_ProfileExporterV3_build`).

Thus, if one wanted to report some data, it first converted it from a `ByteSlice` into a `Buffer`, and then invoke `libddprof` with it.

Here's a (simplified) example from the Ruby profiler:

```c
  ddprof_ffi_File files[1];
  ddprof_ffi_Slice_file slice_files = {.ptr = files, .len = 1};

  ddprof_ffi_Buffer *pprof_buffer =
    ddprof_ffi_Buffer_from_byte_slice((ddprof_ffi_ByteSlice) {
      .ptr = /* byte array with data we want to send */,
      .len = /* ... */
    });

  files[0] = (ddprof_ffi_File) {.name = /* ... */, .file = pprof_buffer};

  ddprof_ffi_Request *request =
    ddprof_ffi_ProfileExporterV3_build(exporter, start, finish, slice_files, timeout_milliseconds);

  ddprof_ffi_Buffer_free(pprof_buffer);
```

This approach had a few downsides:

1. It copied the data to be reported twice. It would be first copied into a `Buffer`, and then inside `ddprof_ffi_ProfileExporterV3_build` it would be copied again.

2. **Callers manually needed to clean up the `Buffer` afterwards using `ddprof_ffi_Buffer_free`**.

After discussing this with @morrisonlevi, we decided to go the other way: change the `File` to contain a `ByteSlice` directly.

This avoids the extra copy in (1.), as well as the caller needing to manage the `Buffer` objects manually in (2.).

This is a breaking API change for libddprof FFI users.

# How to test the change?

Validate that any FFI user (such as `examples/ffi/exporter.cpp`) can still successfully report data after the update.

I've validated locally with the Ruby profiler (PR incoming at some point); ~I could not build `examples/ffi/exporter.cpp` due to unrelated reasons -- I'll tackle it separately from this PR.~

Update: Pushed a couple of commits to update `exporter.cpp`, and confirmed it still works fine.