### PR TITLE
Bump version to v0.5.0-rc.1

### DIFF
--- a/ddprof-exporter/Cargo.toml
+++ b/ddprof-exporter/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-exporter"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/ddprof-ffi/Cargo.toml
+++ b/ddprof-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-ffi"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 edition = "2018"
 license = "Apache-2.0"
 
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 chrono = "0.4"
-ddprof-exporter = { path = "../ddprof-exporter", version = "0.4.0-rc.1" }
-ddprof-profiles = { path = "../ddprof-profiles", version = "0.4.0-rc.1" }
+ddprof-exporter = { path = "../ddprof-exporter", version = "0.5.0-rc.1" }
+ddprof-profiles = { path = "../ddprof-profiles", version = "0.5.0-rc.1" }
 libc = "0.2"
 hyper = { version = "0.14", default-features = false }

--- a/ddprof-profiles/Cargo.toml
+++ b/ddprof-profiles/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-profiles"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 edition = "2018"
 build = "build.rs"
 license = "Apache-2.0"

--- a/ddprof/Cargo.toml
+++ b/ddprof/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 edition = "2018"
 license = "Apache-2.0"
 


### PR DESCRIPTION
# What does this PR do?

Bumps the version to v0.5.0-rc.1

# Motivation

I want to ship the HTTP client and API changes.

# Additional Notes

<3 everyone who contributed.

# How to test the change?

This has breaking changes from v0.4.0-rc.1. You have to fix up some ByteSlice to CharSlice changes. Potentially you may hit some removed APIs (but shouldn't be, we asked around before removing them). If so you have to migrate to the newer v3 APIs.
