### PR TITLE
Ruby updates: 0.5.0 packaging + package arm64 + change fallback package strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "ddprof"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "ddprof-exporter",
  "ddprof-profiles",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ddprof-exporter"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "ddprof-ffi"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "chrono",
  "ddprof-exporter",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "ddprof-profiles"
-version = "0.4.0-rc.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "indexmap",
  "libc",

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -13,15 +13,25 @@ RSpec::Core::RakeTask.new(:spec)
 
 LIB_GITHUB_RELEASES = {
   # This should match the version in the version.rb file
-  "0.3.0" => [
+  "0.5.0" => [
+    {
+      file: "libddprof-aarch64-alpine-linux-musl.tar.gz",
+      sha256: "121857f371fed5252654e6eebcb214c6d3a5b089c7e3340e41ab2089df0b9a25",
+      ruby_platform: "aarch64-linux-musl"
+    },
+    {
+      file: "libddprof-aarch64-unknown-linux-gnu.tar.gz",
+      sha256: "ab4cd1fc9bc3975775bd2ff2122ac0b475533d504965b931d377cca122f7b0b3",
+      ruby_platform: "aarch64-linux"
+    },
     {
       file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
-      sha256: "854609c1acc86f6653f539b3fe8780ad1e60d8738f85efdb3b1aa0054e75a217",
+      sha256: "1675e6402973548ca22da0832babe33d0d4ec739ff9979a600677722fd46ff2f",
       ruby_platform: "x86_64-linux-musl"
     },
     {
       file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
-      sha256: "d9c64567e7ef5f957581dd81892b144b81e1f52fdf5671430c7af0b039b48929",
+      sha256: "2db92e2ad87005a043e415fd62079af1f1df3642be9bed3ade840c5533a61063",
       ruby_platform: "x86_64-linux"
     }
   ]
@@ -87,6 +97,7 @@ task package: [
   # We include both glibc and musl variants in the same binary gem to avoid the issues
   # documented in https://github.com/rubygems/rubygems/issues/3174
   Helpers.package_for(gemspec, ruby_platform: "x86_64-linux", files: Helpers.files_for("x86_64-linux", "x86_64-linux-musl"))
+  Helpers.package_for(gemspec, ruby_platform: "aarch64-linux", files: Helpers.files_for("aarch64-linux", "aarch64-linux-musl"))
 
   # Experimental macOS package, not published to rubygems.org at the moment
   if ENV["LIBDDPROF_PACKAGE_MACOS"] == "true"

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -114,6 +114,7 @@ task push_to_rubygems: [
 
   system("gem push pkg/libddprof-#{Libddprof::VERSION}.gem")
   system("gem push pkg/libddprof-#{Libddprof::VERSION}-x86_64-linux.gem")
+  system("gem push pkg/libddprof-#{Libddprof::VERSION}-aarch64-linux.gem")
 
   system("gem signout") # leave no credentials behind
 end

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -91,8 +91,13 @@ task package: [
   gemspec = eval(File.read("libddprof.gemspec"), nil, "libddprof.gemspec") # standard:disable Security/Eval
   FileUtils.mkdir_p("pkg")
 
-  # Fallback package without binaries
-  Helpers.package_for(gemspec, ruby_platform: nil, files: [])
+  # Fallback package with all binaries
+  # This package will get used by (1) platforms that have no matching `ruby_platform` or (2) that have set
+  # "BUNDLE_FORCE_RUBY_PLATFORM" (or its equivalent via code) to avoid precompiled gems.
+  # In a previous version of libddprof, this package had no binaries, but that could mean that we broke customers in case (2).
+  # For customers in case (1), this package is a no-op, and dd-trace-rb will correctly detect and warn that
+  # there are no valid binaries for the platform.
+  Helpers.package_for(gemspec, ruby_platform: nil, files: Helpers.files_for("x86_64-linux", "x86_64-linux-musl", "aarch64-linux", "aarch64-linux-musl"))
 
   # We include both glibc and musl variants in the same binary gem to avoid the issues
   # documented in https://github.com/rubygems/rubygems/issues/3174

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -154,15 +154,11 @@ module Helpers
     excluded_files: [
       "ddprof_ffi.pc", # we use the ddprof_ffi_with_rpath.pc variant
       "libddprof_ffi.a", "ddprof_ffi-static.pc", # We don't use the static library
-      "libddprof_ffi.so.debug" # We don't include debug info
+      "libddprof_ffi.so.debug", # We don't include debug info
+      "DDProfConfig.cmake" # We don't compile using cmake
     ]
   )
     files = []
-
-    excluded_files_from_packaging = [
-      *excluded_files,
-      "DDProfConfig.cmake" # We don't compile using cmake
-    ]
 
     each_github_release_variant(version: version) do |ruby_platform:, target_directory:, target_file:, **_|
       next unless included_platforms.include?(ruby_platform)
@@ -173,7 +169,7 @@ module Helpers
         Dir.glob("#{target_directory}/**/*")
           .select { |path| File.file?(path) }
           .reject { |path| path == downloaded_release_tarball }
-          .reject { |path| excluded_files_from_packaging.include?(File.basename(path)) }
+          .reject { |path| excluded_files.include?(File.basename(path)) }
     end
 
     files

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -153,7 +153,8 @@ module Helpers
     version: Libddprof::LIB_VERSION,
     excluded_files: [
       "ddprof_ffi.pc", # we use the ddprof_ffi_with_rpath.pc variant
-      "libddprof_ffi.a", "ddprof_ffi-static.pc" # We don't use the static library
+      "libddprof_ffi.a", "ddprof_ffi-static.pc", # We don't use the static library
+      "libddprof_ffi.so.debug" # We don't include debug info
     ]
   )
     files = []

--- a/ruby/lib/libddprof.rb
+++ b/ruby/lib/libddprof.rb
@@ -3,11 +3,6 @@
 require_relative "libddprof/version"
 
 module Libddprof
-  # Does this libddprof release include any binaries?
-  def self.binaries?
-    available_binaries.any?
-  end
-
   # This should only be used for debugging/logging
   def self.available_binaries
     File.directory?(vendor_directory) ? (Dir.entries(vendor_directory) - [".", ".."]) : []

--- a/ruby/lib/libddprof.rb
+++ b/ruby/lib/libddprof.rb
@@ -13,12 +13,12 @@ module Libddprof
     File.directory?(vendor_directory) ? (Dir.entries(vendor_directory) - [".", ".."]) : []
   end
 
-  def self.pkgconfig_folder
+  def self.pkgconfig_folder(pkgconfig_file_name = "ddprof_ffi_with_rpath.pc")
     current_platform = Gem::Platform.local.to_s
 
     return unless available_binaries.include?(current_platform)
 
-    pkgconfig_file = Dir.glob("#{vendor_directory}/#{current_platform}/**/ddprof_ffi.pc").first
+    pkgconfig_file = Dir.glob("#{vendor_directory}/#{current_platform}/**/#{pkgconfig_file_name}").first
 
     return unless pkgconfig_file
 

--- a/ruby/lib/libddprof/version.rb
+++ b/ruby/lib/libddprof/version.rb
@@ -2,11 +2,11 @@
 
 module Libddprof
   # Current libddprof version
-  LIB_VERSION = "0.3.0"
+  LIB_VERSION = "0.5.0"
 
-  GEM_MAJOR_VERSION = "2"
+  GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"
-  GEM_PRERELEASE_VERSION = ".beta1" # remember to include dot prefix, if needed!
+  GEM_PRERELEASE_VERSION = "" # remember to include dot prefix, if needed!
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].

--- a/ruby/libddprof.gemspec
+++ b/ruby/libddprof.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
       .reject do |f|
         [".rspec", ".standard.yml", "Rakefile", "docker-compose.yml", "gems.rb", "README.md"].include?(f)
       end
+      .reject { |f| f.end_with?(".tar.gz") }
   end
   spec.require_paths = ["lib"]
 end

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Libddprof do
 
         before do
           FileUtils.mkdir_p(pkgconfig_folder)
-          File.open("#{pkgconfig_folder}/ddprof_ffi.pc", "w") {}
+          File.open("#{pkgconfig_folder}/ddprof_ffi_with_rpath.pc", "w") {}
         end
 
         describe ".pkgconfig_folder" do

--- a/ruby/spec/libddprof_spec.rb
+++ b/ruby/spec/libddprof_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Libddprof do
     end
 
     context "when no binaries are available in the vendor directory" do
-      describe ".binaries?" do
-        it { expect(Libddprof.binaries?).to be false }
-      end
-
       describe ".available_binaries" do
         it { expect(Libddprof.available_binaries).to be_empty }
       end
@@ -46,10 +42,6 @@ RSpec.describe Libddprof do
 
     context "when vendor directory does not exist" do
       let(:temporary_directory) { "does/not/exist" }
-
-      describe ".binaries?" do
-        it { expect(Libddprof.binaries?).to be false }
-      end
 
       describe ".available_binaries" do
         it { expect(Libddprof.available_binaries).to be_empty }
@@ -64,10 +56,6 @@ RSpec.describe Libddprof do
       before do
         Dir.mkdir("#{temporary_directory}/386-freedos")
         Dir.mkdir("#{temporary_directory}/mipsel-linux")
-      end
-
-      describe ".binaries?" do
-        it { expect(Libddprof.binaries?).to be true }
       end
 
       describe ".available_binaries" do


### PR DESCRIPTION
# What does this PR do?

This PR prepares the 0.5.0 Ruby packages, and includes a bunch of changes to take advantage of 0.5 improvements:

* Exclude debug information from Ruby packages
* Package Linux arm64 releases for Ruby
* Changes the strategy for the fallback package with no platform (see more details in the change to the `Rakefile`)

(I've broken it into separate commits which hopefully will make sense individually)

# Motivation

Release latest improvements for usage by the Ruby profiler.

# Additional Notes

Using `docker-compose run push_to_rubygems` to release the packages won't work until we actually upload the 0.5.0-rc.1 binaries as 0.5.0. I built the packages locally and validated the dd-trace-rb tests are green (see "How to test the change?" below).

Also note that libddprof is not yet being used in any released version of dd-trace-rb, and more validation will be done on the Ruby side before we do so.

# How to test the change?

Libddprof integration is still in PR for dd-trace-rb. Testing can be done with https://github.com/DataDog/dd-trace-rb/pull/1936 . I've built the packages locally without releasing them, and validated that libddprof integration tests in the mentioned PR are all passing. 