### PR TITLE
Test rust 1.56.1 compatibility

### DIFF
--- a/.github/actions/cache/action.yaml
+++ b/.github/actions/cache/action.yaml
@@ -1,6 +1,11 @@
 name: '[rust] Cache' 
 description: '[rust] Cache'
 
+inputs:
+  rust_version:
+    default: "latest"
+    required: false
+
 runs:
   using: composite
   steps:
@@ -12,4 +17,4 @@ runs:
           ~/.cargo/git/db/
           ~/.cargo/bin/
           target/
-        key: v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+        key: v1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ inputs.rust_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,28 @@ env:
 
 jobs:
   test:
-    name: "cargo test --workspace #${{ matrix.platform }}"
+    name: "cargo test --workspace #${{ matrix.platform }} ${{ matrix.rust_version }}"
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
         platform: [windows-latest, ubuntu-latest, macos-latest] 
+        rust_version: [""]
+        include:
+          - platform: "ubuntu-latest"
+            rust_version: "1.56.1"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Cache
         uses: ./.github/actions/cache
-      - run: cargo build --workspace --verbose
-      - run: cargo test --workspace --verbose
+        with:
+          rust_version: ${{ matrix.rust_version }}
+      - name: Install Rust ${{ matrix.rust_version }}
+        if: ${{ matrix.rust_version != '' }}
+        run: rustup install ${{ matrix.rust_version }} && rustup default ${{ matrix.rust_version }}
+      - id: rust-version
+        run: "echo ::set-output name=version::$(rustc --version)"
+      - name: "[${{ steps.rust-version.outputs.version}}] cargo build --workspace --verbose"
+        run: cargo build --workspace --verbose
+      - name: "[${{ steps.rust-version.outputs.version}}] cargo test --workspace --verbose"
+        run: cargo test --workspace --verbose


### PR DESCRIPTION
# What does this PR do?

Ensures that all pushed code will be compatible with rust 1.56.1 which is the current version supported in alpine's custom rustc version

